### PR TITLE
Fix default Templates location

### DIFF
--- a/Stellar/Sources/CLI/Commands/URLManager.swift
+++ b/Stellar/Sources/CLI/Commands/URLManager.swift
@@ -9,8 +9,7 @@ final class URLManager {
         if let templates = templates {
             return URL(fileURLWithPath: templates)
         }
-        return URL(fileURLWithPath: CommandLine.arguments.first!)
-            .deletingLastPathComponent()
-            .appendingPathExtension(FolderConstants.templatesFolder)
+        return URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent(FolderConstants.templatesFolder)
     }
 }


### PR DESCRIPTION
When running the `StellarCLI` executable without the `--templates` parameter, the default location of the `Templates` folder was incorrect. Following up #12.