### PR TITLE
Zip Templates folder as part of the release

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -39,9 +39,12 @@ jobs:
       - name: Archive using ${{ matrix.scheme }} for destination ${{ matrix.destination }}
         working-directory: ./Stellar
         run: swift build -c release --arch arm64 --arch x86
+      - name: Copy Templates folder
+        working-directory: ./Stellar
+        run: cp -r Templates .build/apple/Products/Release/
       - name: Zip executable
         working-directory: ./Stellar/.build/apple/Products/Release/
-        run: zip StellarCLI.zip StellarCLI
+        run: zip StellarCLI.zip StellarCLI Templates/**/*
       - name: Create Release
         uses: actions/create-release@v1
         id: create_release


### PR DESCRIPTION
Now that we have the templates parameter as optional and default to the location of the executable (#12 and #15), we can put the `Templates` folder as part of the release.