### PR TITLE
Fix zip step in build-and-release.yml

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -44,7 +44,7 @@ jobs:
         run: cp -r Templates .build/apple/Products/Release/
       - name: Zip executable
         working-directory: ./Stellar/.build/apple/Products/Release/
-        run: zip StellarCLI.zip StellarCLI Templates/**/*
+        run: zip -r StellarCLI.zip StellarCLI Templates
       - name: Create Release
         uses: actions/create-release@v1
         id: create_release


### PR DESCRIPTION
The release zip was created with missing files deeper than 2 levels, only reproducible on GitHub Actions.
It seriously looks to me like a bug in `zip`, as the `**` glob is very much Linux standard, and `zip` is the same version locally and remotely (v3.0.0).

I'm now using the `-r` parameter to recursively zip all files.

Go figure!