### PR TITLE
Add VersionCommand printing the version of the tool

### DIFF
--- a/Stellar/.swiftpm/xcode/xcshareddata/xcschemes/StellarCLI [version].xcscheme
+++ b/Stellar/.swiftpm/xcode/xcshareddata/xcschemes/StellarCLI [version].xcscheme
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "StellarCLI"
+               BuildableName = "StellarCLI"
+               BlueprintName = "StellarCLI"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      viewDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "StellarCLI"
+            BuildableName = "StellarCLI"
+            BlueprintName = "StellarCLI"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "version"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "StellarCLI"
+            BuildableName = "StellarCLI"
+            BlueprintName = "StellarCLI"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Stellar/Sources/CLI/Commands/VersionCommand.swift
+++ b/Stellar/Sources/CLI/Commands/VersionCommand.swift
@@ -1,0 +1,15 @@
+//  VersionCommand.swift
+
+import ArgumentParser
+import Foundation
+import StellarCore
+
+struct VersionCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "version",
+        abstract: "Outputs the current version of the tool")
+    
+    func run() throws {
+        try VersionService().run()
+    }
+}

--- a/Stellar/Sources/CLI/Constants/Constants.swift
+++ b/Stellar/Sources/CLI/Constants/Constants.swift
@@ -1,0 +1,7 @@
+//  Constants.swift
+
+import Foundation
+
+enum Constants {
+    static let version = "0.1.0"
+}

--- a/Stellar/Sources/CLI/Constants/FolderConstants.swift
+++ b/Stellar/Sources/CLI/Constants/FolderConstants.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-struct FolderConstants {
+enum FolderConstants {
     static let templatesFolder = "Templates"
     static let dotStellarActionsFolder = ".stellar/Actions"
 }

--- a/Stellar/Sources/CLI/Stellar.swift
+++ b/Stellar/Sources/CLI/Stellar.swift
@@ -13,7 +13,8 @@ struct Stellar: AsyncParsableCommand {
             CreateActionCommand.self,
             CreateTaskCommand.self,
             EditCommand.self,
-            InitCommand.self
+            InitCommand.self,
+            VersionCommand.self
         ]
     )
 }

--- a/Stellar/Sources/CLI/VersionService/VersionService.swift
+++ b/Stellar/Sources/CLI/VersionService/VersionService.swift
@@ -1,0 +1,10 @@
+//  VersionService.swift
+
+import Foundation
+import StellarCore
+
+final class VersionService {
+    func run() throws {
+        Logger().log("\(Constants.version)")
+    }
+}

--- a/Stellar/Sources/Core/Logger/Logger.swift
+++ b/Stellar/Sources/Core/Logger/Logger.swift
@@ -4,6 +4,8 @@ import Foundation
 
 public class Logger {
     
+    public init() {}
+    
     public func log(_ message: String) {
         print("[\(Constants.stellar)] \(message)")
     }


### PR DESCRIPTION
Per title.
Very much inspired by Tuist.
It doesn't seem there is a standard to do this (see [here](https://stackoverflow.com/a/62001912/3010877)).
Will be useful to @malcommac when testing different versions via `stellarenv`.